### PR TITLE
Mutualism Feature

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,15 @@
-# treeducken 1.1.0
+# treeducken 1.1.1
+
+## Major changes
+
+* Added mutualism boolean for simulation
+
+
+## Bug fixes
+
+* Fixed a bug where instead of skipping a replicate when using `summarize_cophy` the function would stop when encountering a dataset where the Parafit couldn't be calculated.
+* Fixed a bug where `summarize_1cophy` would have NA as the column name if the column value had NA
+
 
 # treeducken 1.1.0
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -209,6 +209,7 @@ sim_cophyBD_ana <- function(hbr, hdr, sbr, sdr, s_disp_r, s_extp_r, host_exp_rat
 #' @param numbsim number of replicates
 #' @param host_limit Maximum number of hosts for symbionts (0 implies no limit)
 #' @param hs_mode Boolean turning host expansion into host switching (explained above) (default = FALSE)
+#' @param mutualism Boolean turning on/off mutualism mode (in mutualism mode hosts are required to have symbionts)
 #' @return A list containing the `host_tree`, the `symbiont_tree`, the
 #'     association matrix in the present, with hosts as rows and symbionts as columns, and the history of events that have
 #'     occurred.
@@ -232,8 +233,8 @@ sim_cophyBD_ana <- function(hbr, hdr, sbr, sdr, s_disp_r, s_extp_r, host_exp_rat
 #'                            numbsim = numb_replicates,
 #'                            time_to_sim = time)
 #'
-sim_cophyBD <- function(hbr, hdr, sbr, sdr, host_exp_rate, cosp_rate, time_to_sim, numbsim, host_limit = 0L, hs_mode = FALSE) {
-    .Call(`_treeducken_sim_cophyBD`, hbr, hdr, sbr, sdr, host_exp_rate, cosp_rate, time_to_sim, numbsim, host_limit, hs_mode)
+sim_cophyBD <- function(hbr, hdr, sbr, sdr, host_exp_rate, cosp_rate, time_to_sim, numbsim, host_limit = 0L, hs_mode = FALSE, mutualism = FALSE) {
+    .Call(`_treeducken_sim_cophyBD`, hbr, hdr, sbr, sdr, host_exp_rate, cosp_rate, time_to_sim, numbsim, host_limit, hs_mode, mutualism)
 }
 
 #' Simulate multispecies coalescent on a species tree

--- a/man/sim_cophyBD.Rd
+++ b/man/sim_cophyBD.Rd
@@ -15,7 +15,8 @@ sim_cophyBD(
   time_to_sim,
   numbsim,
   host_limit = 0L,
-  hs_mode = FALSE
+  hs_mode = FALSE,
+  mutualism = FALSE
 )
 
 sim_cophylo_bdp(
@@ -50,6 +51,8 @@ sim_cophylo_bdp(
 \item{host_limit}{Maximum number of hosts for symbionts (0 implies no limit)}
 
 \item{hs_mode}{Boolean turning host expansion into host switching (explained above) (default = FALSE)}
+
+\item{mutualism}{Boolean turning on/off mutualism mode (in mutualism mode hosts are required to have symbionts)}
 }
 \value{
 A list containing the `host_tree`, the `symbiont_tree`, the

--- a/src/Cophylo.cpp
+++ b/src/Cophylo.cpp
@@ -4,17 +4,17 @@
 using namespace Rcpp;
 
 Rcpp::List sim_host_symb_treepair_ana(double hostbr,
-                                  double hostdr,
-                                  double symbbr,
-                                  double symbdr,
-                                  double symb_dispersal,
-                                  double symb_extirpation,
-                                  double switchRate,
-                                  double cospeciationRate,
-                                  double timeToSimTo,
-                                  int host_limit,
-                                  int numbsim,
-                                  bool hsMode){
+                                      double hostdr,
+                                      double symbbr,
+                                      double symbdr,
+                                      double symb_dispersal,
+                                      double symb_extirpation,
+                                      double switchRate,
+                                      double cospeciationRate,
+                                      double timeToSimTo,
+                                      int host_limit,
+                                      int numbsim,
+                                      bool hsMode) {
     double rho = 1.0;
     Rcpp::List multiphy;
     Rcpp::List hostSymbPair;
@@ -78,23 +78,22 @@ Rcpp::List sim_host_symb_treepair(double hostbr,
                                   double timeToSimTo,
                                   int host_limit,
                                   int numbsim,
-                                  bool hsMode){
+                                  bool hsMode,
+                                  bool mutualism){
 
     double rho = 1.0;
     Rcpp::List multiphy;
     Rcpp::List hostSymbPair;
     for(int i = 0; i < numbsim; i++){
-        // auto phySimulator = std::shared_ptr<Simulator>(new Simulator( timeToSimTo,
-        //                                          hostbr,
-        //                                          hostdr,
-        //                                          symbbr,
-        //                                          symbdr,
-        //                                          switchRate,
-        //                                          cospeciationRate,
-        //                                          rho,
-        //                                          host_limit,
-        //                                          hsMode));
-        Simulator phySimulator(Simulator::CophySim(hostbr, hostdr, symbdr, symbdr, switchRate, cospeciationRate, timeToSimTo, host_limit, hsMode));
+        Simulator phySimulator(Simulator::CophySim(hostbr, 
+                                                   hostdr, 
+                                                   symbbr, 
+                                                   symbdr, 
+                                                   switchRate, cospeciationRate,
+                                                   timeToSimTo, 
+                                                   host_limit, 
+                                                   hsMode, 
+                                                   mutualism));
         phySimulator.simHostSymbSpeciesTreePair();
 
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -74,8 +74,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // sim_cophyBD
-Rcpp::List sim_cophyBD(SEXP hbr, SEXP hdr, SEXP sbr, SEXP sdr, SEXP host_exp_rate, SEXP cosp_rate, SEXP time_to_sim, SEXP numbsim, Rcpp::NumericVector host_limit, Rcpp::LogicalVector hs_mode);
-RcppExport SEXP _treeducken_sim_cophyBD(SEXP hbrSEXP, SEXP hdrSEXP, SEXP sbrSEXP, SEXP sdrSEXP, SEXP host_exp_rateSEXP, SEXP cosp_rateSEXP, SEXP time_to_simSEXP, SEXP numbsimSEXP, SEXP host_limitSEXP, SEXP hs_modeSEXP) {
+Rcpp::List sim_cophyBD(SEXP hbr, SEXP hdr, SEXP sbr, SEXP sdr, SEXP host_exp_rate, SEXP cosp_rate, SEXP time_to_sim, SEXP numbsim, Rcpp::NumericVector host_limit, Rcpp::LogicalVector hs_mode, Rcpp::LogicalVector mutualism);
+RcppExport SEXP _treeducken_sim_cophyBD(SEXP hbrSEXP, SEXP hdrSEXP, SEXP sbrSEXP, SEXP sdrSEXP, SEXP host_exp_rateSEXP, SEXP cosp_rateSEXP, SEXP time_to_simSEXP, SEXP numbsimSEXP, SEXP host_limitSEXP, SEXP hs_modeSEXP, SEXP mutualismSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -89,7 +89,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< SEXP >::type numbsim(numbsimSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type host_limit(host_limitSEXP);
     Rcpp::traits::input_parameter< Rcpp::LogicalVector >::type hs_mode(hs_modeSEXP);
-    rcpp_result_gen = Rcpp::wrap(sim_cophyBD(hbr, hdr, sbr, sdr, host_exp_rate, cosp_rate, time_to_sim, numbsim, host_limit, hs_mode));
+    Rcpp::traits::input_parameter< Rcpp::LogicalVector >::type mutualism(mutualismSEXP);
+    rcpp_result_gen = Rcpp::wrap(sim_cophyBD(hbr, hdr, sbr, sdr, host_exp_rate, cosp_rate, time_to_sim, numbsim, host_limit, hs_mode, mutualism));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -116,7 +117,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_treeducken_sim_stBD_t", (DL_FUNC) &_treeducken_sim_stBD_t, 4},
     {"_treeducken_sim_ltBD", (DL_FUNC) &_treeducken_sim_ltBD, 6},
     {"_treeducken_sim_cophyBD_ana", (DL_FUNC) &_treeducken_sim_cophyBD_ana, 12},
-    {"_treeducken_sim_cophyBD", (DL_FUNC) &_treeducken_sim_cophyBD, 10},
+    {"_treeducken_sim_cophyBD", (DL_FUNC) &_treeducken_sim_cophyBD, 11},
     {"_treeducken_sim_msc", (DL_FUNC) &_treeducken_sim_msc, 7},
     {NULL, NULL, 0}
 };

--- a/src/Simulator.h
+++ b/src/Simulator.h
@@ -22,6 +22,7 @@ class Simulator
         double      popSize;
         double      generationTime;
         bool        host_switch_mode;
+        bool        mutualism;
         std::vector<std::shared_ptr<SpeciesTree>>   gsaTrees;
         std::shared_ptr<SpeciesTree>    spTree;
         std::shared_ptr<LocusTree>      lociTree;
@@ -121,23 +122,25 @@ class Simulator
         };
         struct CophySim {
             inline CophySim(double hostbr,
-                                double hostdr,
-                                double symbbr,
-                                double symbdr,
-                                double switchrate,
-                                double cosprate,
-                                double timeToSimTo,
-                                int host_limit,
-                                bool hsMode): 
-                                    hostBirthRate(hostbr),
-                                    hostDeathRate(hostdr),
-                                    symbDeathRate(symbdr),
-                                    symbBirthRate(symbbr),
-                                    switchingRate(switchrate),
-                                    cospeciationRate(cosprate),
-                                    timeToSimTo(timeToSimTo),
-                                    hostLimit(host_limit),
-                                    hsMode(hsMode) {}
+                            double hostdr,
+                            double symbbr,
+                            double symbdr,
+                            double switchrate,
+                            double cosprate,
+                            double timeToSimTo,
+                            int host_limit,
+                            bool hsMode,
+                            bool mutualism): 
+                                hostBirthRate(hostbr),
+                                hostDeathRate(hostdr),
+                                symbDeathRate(symbdr),
+                                symbBirthRate(symbbr),
+                                switchingRate(switchrate),
+                                cospeciationRate(cosprate),
+                                timeToSimTo(timeToSimTo),
+                                hostLimit(host_limit),
+                                hsMode(hsMode),
+                                mutualism(mutualism) {}
             double hostBirthRate;
             double hostDeathRate;
             double symbDeathRate;
@@ -147,6 +150,7 @@ class Simulator
             double timeToSimTo;
             unsigned hostLimit;
             bool hsMode;
+            bool mutualism;
         };
         struct CophySimAna {
 
@@ -271,6 +275,7 @@ class Simulator
         arma::umat symbiontDispersalEvent(int symbInd, arma::umat assocMat);
         arma::umat symbiontExtirpationEvent(int symbInd, arma::umat assocMat);
         arma::umat anageneticEvent(double dispersalRate, double extirpationRate, double currTime, arma::umat assocMat);
+        arma::umat symbsOnHosts(arma::umat assocMat, unsigned hosts, double t);
 
 };
 
@@ -301,7 +306,8 @@ extern Rcpp::List sim_host_symb_treepair(double hostbr,
                                          double timeToSimTo,
                                          int host_limit,
                                          int numbsim,
-                                         bool hsMode);
+                                         bool hsMode,
+                                         bool mutualism);
 
 extern Rcpp::List sim_host_symb_treepair_ana(double hostbr,
                                             double hostdr,

--- a/src/SymbiontTree.cpp
+++ b/src/SymbiontTree.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "SymbiontTree.h"
-
 #include "math.h"
 SymbiontTree::SymbiontTree(int nt,
                            double ct,

--- a/src/Treeducken.cpp
+++ b/src/Treeducken.cpp
@@ -16,12 +16,10 @@ Rcpp::List bdsim_species_tree(double sbr,
 
     List multiphy(numbsim);
     for(int i = 0; i < numbsim; i++){
- //       std::shared_ptr<Simulator> phySimulator = std::shared_ptr<Simulator>(new Simulator(n_tips,
-                                                                 //                           sbr,
-                                                                  //                          sdr,
-                                                                   //                         1));
-        Simulator phySimulator(Simulator::SpeciesSimTips(sbr, sdr, gsa_stop, n_tips));
-        //phySimulator.setGSAStop(gsa_stop);
+        Simulator phySimulator(Simulator::SpeciesSimTips(sbr, 
+                                                        sdr, 
+                                                        gsa_stop, 
+                                                        n_tips));
         phySimulator.simSpeciesTree();
 
         List phy = List::create(Named("edge") = phySimulator.getSpeciesEdges(),
@@ -47,13 +45,8 @@ Rcpp::List sim_bdsimple_species_tree(double sbr,
     List multiphy(numbsim);
     for(int i = 0; i < numbsim; i++){
 
-        // auto phySimulator = std::shared_ptr<Simulator>(new Simulator(1,
-        //                                                               sbr,
-        //                                                               sdr,
-        //                                                               1));
         Simulator phySimulator(Simulator::SpeciesSimTime(sbr,sdr, timeToSimTo));
 
-//        phySimulator.setTimeToSim(timeToSimTo);
         phySimulator.simSpeciesTreeTime();
 
         List phy = List::create(Named("edge") = phySimulator.getSpeciesEdges(),
@@ -83,16 +76,6 @@ Rcpp::List sim_locus_tree(std::shared_ptr<SpeciesTree> species_tree,
     unsigned numLociToSim = numLoci;
     for(int i = 0; i < numLoci; i++){
 
-        // auto phySimulator = std::shared_ptr<Simulator>(new Simulator( ntax,
-        //                                                 lambda,
-        //                                                 mu,
-        //                                                 rho,
-        //                                                 numLociToSim,
-        //                                                 gbr,
-        //                                                 gdr,
-        //                                                 lgtr,
-        //                                                 trans_type));
-        // phySimulator.setSpeciesTree(species_tree);
         Simulator phySimulator(Simulator::LocusSim(species_tree, gbr, gdr, lgtr, trans_type));
         phySimulator.simLocusTree();
         List phy = List::create(Named("edge") = phySimulator.getLocusEdges(),
@@ -131,22 +114,6 @@ Rcpp::List sim_locus_tree_gene_tree(std::shared_ptr<SpeciesTree> species_tree,
     // bool sout = false;
     // double og = 0.0;
     for(int i = 0; i < numLoci; i++){
-
-        // auto phySimulator = std::shared_ptr<Simulator>(new Simulator(ntax,
-        //                                                 lambda,
-        //                                                 mu,
-        //                                                 rho,
-        //                                                 numLociToSim,
-        //                                                 gbr,
-        //                                                 gdr,
-        //                                                 lgtr,
-        //                                                 samples_per_lineage,
-        //                                                 popsize,
-        //                                                 genTime,
-        //                                                 numGenesPerLocus,
-        //                                                 og,
-        //                                                 ts,
-        //                                                 sout));
 
         Simulator phySimulator(Simulator::LocusAndGeneMSCSim(species_tree, gbr, gdr, lgtr, popsize, numLoci, samples_per_lineage, numGenesPerLocus));
 //        phySimulator.setSpeciesTree(species_tree);

--- a/src/rcpp_treeducken.cpp
+++ b/src/rcpp_treeducken.cpp
@@ -340,6 +340,7 @@ Rcpp::List sim_cophyBD_ana(SEXP hbr,
 //' @param numbsim number of replicates
 //' @param host_limit Maximum number of hosts for symbionts (0 implies no limit)
 //' @param hs_mode Boolean turning host expansion into host switching (explained above) (default = FALSE)
+//' @param mutualism Boolean turning on/off mutualism mode (in mutualism mode hosts are required to have symbionts)
 //' @return A list containing the `host_tree`, the `symbiont_tree`, the
 //'     association matrix in the present, with hosts as rows and symbionts as columns, and the history of events that have
 //'     occurred.
@@ -373,7 +374,8 @@ Rcpp::List sim_cophyBD(SEXP hbr,
                     SEXP time_to_sim,
                     SEXP numbsim,
                     Rcpp::NumericVector host_limit = 0,
-                    Rcpp::LogicalVector hs_mode = false){
+                    Rcpp::LogicalVector hs_mode = false,
+                    Rcpp::LogicalVector mutualism = false){
     double hbr_ = as<double>(hbr);
     double hdr_ = as<double>(hdr);
     double sbr_ = as<double>(sbr);
@@ -384,6 +386,7 @@ Rcpp::List sim_cophyBD(SEXP hbr,
     double timeToSimTo_ = as<double>(time_to_sim);
     int numbsim_ = as<int>(numbsim);
     bool host_switch_mode_ = as<bool>(hs_mode);
+    bool mutualism_ = as<bool>(mutualism);
     RNGScope scope;
     if(hbr_ < 0.0){
          stop("'hbr' must be positive or 0.0.");
@@ -415,7 +418,8 @@ Rcpp::List sim_cophyBD(SEXP hbr,
                                   timeToSimTo_,
                                   hl_,
                                   numbsim_,
-                                  host_switch_mode_);
+                                  host_switch_mode_,
+                                  mutualism_);
 }
 //' Simulate multispecies coalescent on a species tree
 //'


### PR DESCRIPTION
Added a new simulation feature. Using the `sim_cophyloBD` function, users can set the `mutualism` boolean. If TRUE, the simulation will force extinction of hosts without symbionts. If FALSE (the deafult), the function allows simulation of hosts with no symbionts.